### PR TITLE
Support mocking singleton-backed static classes.

### DIFF
--- a/MockAttribute.cs
+++ b/MockAttribute.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 
-namespace NMockito
-{
-   public class MockAttribute : Attribute
-   {
+namespace NMockito {
+   public class MockAttribute : Attribute {
       private bool tracked;
+      private Type staticType;
 
-      public MockAttribute(Tracking tracking = Tracking.Tracked) {
-         this.Tracked = tracking == Tracking.Tracked;
+      public MockAttribute(Tracking tracking = Tracking.Tracked, Type staticType = null) {
+         this.tracked = tracking == Tracking.Tracked;
+         this.staticType = staticType;
       }
 
       public bool Tracked { get { return tracked; } set { tracked = value; } }
+      public Type StaticType { get { return staticType; } set { staticType = value; } }
    }
 }

--- a/NMockito.Test/NMockito.Test.csproj
+++ b/NMockito.Test/NMockito.Test.csproj
@@ -59,6 +59,7 @@
     <Compile Include="OutTests.cs" />
     <Compile Include="Properties\Annotations.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SingletonMockingTest.cs" />
     <Compile Include="VoidMockingTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NMockito.Test/SingletonMockingTest.cs
+++ b/NMockito.Test/SingletonMockingTest.cs
@@ -1,0 +1,29 @@
+﻿using Xunit;
+
+namespace NMockito {
+   public class SingletonMockingTest : NMockitoInstance {
+      [Mock(StaticType = typeof(Util))] private readonly UtilInterface util = null;
+
+      [Fact]
+      public void Run() {
+         When(util.GetCount()).ThenReturn(1);
+         AssertEquals(1, Util.GetCount());
+      }
+   }
+
+   public static class Util {
+      private static readonly UtilInterface instance = new UtilImpl();
+
+      public static int GetCount() => instance.GetCount();
+   }
+
+   public interface UtilInterface {
+      int GetCount();
+   }
+
+   public class UtilImpl : UtilInterface {
+      public int GetCount() {
+         return 0;
+      }
+   }
+}

--- a/NMockito.sln
+++ b/NMockito.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22609.0
+VisualStudioVersion = 14.0.22310.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NMockito", "NMockito.csproj", "{0060E29C-DB43-45A8-97AF-17D4AEF0DAD7}"
 EndProject

--- a/NMockitoAttributes.cs
+++ b/NMockitoAttributes.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Linq;
 using System.Reflection;
+using Castle.DynamicProxy.Internal;
 
-namespace NMockito
-{
+namespace NMockito {
    public static class NMockitoAttributes
    {
       public static void InitializeMocks(object target)
@@ -13,8 +12,24 @@ namespace NMockito
          foreach (var field in fields) {
             var mockAttribute = field.GetCustomAttribute<MockAttribute>();
             if (mockAttribute != null) {
-               var fieldType = field.FieldType;
-               field.SetValue(target, NMockitoStatic.CreateMock(fieldType, mockAttribute.Tracked));
+               InitializeMockedField(target, field, mockAttribute);
+            }
+         }
+      }
+
+      private static void InitializeMockedField(object target, FieldInfo mockField, MockAttribute mockAttribute) {
+         var fieldType = mockField.FieldType;
+         var mock = NMockitoStatic.CreateMock(fieldType, mockAttribute.Tracked);
+         mockField.SetValue(target, mock);
+
+         var staticType = mockAttribute.StaticType;
+         if (staticType != null) {
+            var staticFields = staticType.GetFields(BindingFlags.NonPublic | BindingFlags.Static);
+            var staticInstanceFields = staticFields.Where(field => field.Name.EndsWith("instance") && field.FieldType == fieldType).ToArray();
+            if (staticInstanceFields.Length != 1) {
+               throw new AmbiguousMatchException("NMockito unable to determine instance field of static " + staticType.FullName + " candidates " + string.Join(", ", staticInstanceFields.Select(f=>f.Name).ToArray()));
+            } else {
+               staticInstanceFields.First().SetValue(null, mock);
             }
          }
       }


### PR DESCRIPTION
The implementation adds a StaticType attribute to MockAttribute. When
our mocking framework's MockAttribute is used with the static type,
we look at the field the MockAttribute is applied to and hope the static
type has an instance of that type.
